### PR TITLE
fix: Søk med mer enn 2 ord

### DIFF
--- a/nettside/src/routes/sok/+page.server.ts
+++ b/nettside/src/routes/sok/+page.server.ts
@@ -8,7 +8,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			products: await prisma.products.findMany({
 				where: {
 					title: {
-						search: url.searchParams.get('search') as string
+						search: url.searchParams.get('search')?.split(" ").join(" & ") as string
 					}
 				}
 			})


### PR DESCRIPTION
## Fiksa sånn at man kan søke med hvor mange ord man vil

### closes #54 

#### Beskrivelse
Var ikke en stor oppgave, var bare en litt dårlig implementasjon av replacing av " " med " & ", som bare replacet et av mellomrommene. Så jeg måtte bruke .split så .join for å fikse det.